### PR TITLE
Upgraded to net8, throw exception in Program.cs, ignore --http_ports command input

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ dotnet test .\netmockery.sln
 
 In linux container
 ```
-docker run --rm -v ${PWD}\:/mnt/repo/ -w /mnt/repo mcr.microsoft.com/dotnet/sdk:6.0 dotnet test .\netmockery.sln
+docker run --rm -v ${PWD}\:/mnt/repo/ -w /mnt/repo mcr.microsoft.com/dotnet/sdk:8.0 dotnet test .\netmockery.sln
 ```
 
 RUNNING

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/netmockery.globals/netmockery.globals.csproj
+++ b/netmockery.globals/netmockery.globals.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/netmockery/CommandLineParser.cs
+++ b/netmockery/CommandLineParser.cs
@@ -25,6 +25,7 @@ namespace netmockery
         private const string BOOL_SWITCH_DIFF = "--diff";
         private const string BOOL_SWITCH_LIST = "--list";
 
+        static private string[] VALUE_SWICTHES_IGNORED = new[] { "--http_ports" }; // Not used, ports are part of urls
         static private string[] VALUE_SWITCHES = new[] { VALUE_SWITCH_ENDPOINTS, VALUE_SWITCH_URLS, VALUE_SWITCH_ONLY, VALUE_UT_SWITCH_ENVIRONMENT, VALUE_UT_SWITCH_CONTENTROOT, VALUE_UT_SWITCH_APPLICATIONNAME };
         static private string[] BOOL_SWITCHES = new[] { BOOL_SWITCH_SHOWRESPONSE, BOOL_SWITCH_NOTESTMODE, BOOL_SWITCH_STOP, BOOL_SWITCH_DIFF, BOOL_SWITCH_LIST };
 
@@ -120,7 +121,11 @@ namespace netmockery
             while (i < args.Length)
             {
                 var arg = args[i];
-                if (VALUE_SWITCHES.Contains(arg))
+                if (VALUE_SWICTHES_IGNORED.Contains(arg))
+                {
+                    i++;
+                }
+                else if (VALUE_SWITCHES.Contains(arg))
                 {
                     var value = args[++i];
                     stringSwitches[arg] = value;

--- a/netmockery/Program.cs
+++ b/netmockery/Program.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -20,16 +20,7 @@ namespace netmockery
 
         public static async Task MainAsync(string[] args)
         {
-            ParsedCommandLine parsedArguments;
-            try
-            {
-                parsedArguments = CommandLineParser.ParseArguments(args);
-            }
-            catch (CommandLineParsingException clpe)
-            {
-                Console.Error.WriteLine($"ERROR: {clpe.Message}");
-                return;
-            }            
+            ParsedCommandLine parsedArguments = CommandLineParser.ParseArguments(args);       
 
             if (!Directory.Exists(parsedArguments.Endpoints))
             {

--- a/netmockery/netmockery.csproj
+++ b/netmockery/netmockery.csproj
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>0.13.0</Version>
-    <AssemblyVersion>0.13.0.0</AssemblyVersion>
-    <FileVersion>0.13.0.0</FileVersion>
+    <Version>0.14.0</Version>
+    <AssemblyVersion>0.14.0.0</AssemblyVersion>
+    <FileVersion>0.14.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <Content Update="wwwroot\*" CopyToPublishDirectory="Always" CopyToOutputDirectory="Always" />

--- a/netmockery/netmockery.csproj
+++ b/netmockery/netmockery.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>0.13.0</Version>
     <AssemblyVersion>0.13.0.0</AssemblyVersion>
     <FileVersion>0.13.0.0</FileVersion>


### PR DESCRIPTION
I throw the exception directly in the `MainAsync` so exceptions arent hidden in tests, as code console output isnt visible in the `dotnet test console` output